### PR TITLE
Fix mobile overflow for theme buttons

### DIFF
--- a/src/components/ThemeSelector.tsx
+++ b/src/components/ThemeSelector.tsx
@@ -83,13 +83,13 @@ export function ThemeSelector({
         Select Theme or Enter Custom Prompt:
       </label>
 
-      <div className="flex space-x-2 mb-4">
+      <div className="flex flex-wrap gap-2 mb-4">
         {themes.map((theme) => (
           <Button
             key={theme.id}
             variant={selectedThemeId === theme.id ? "default" : "outline"}
             onClick={() => onThemeSelect(theme.id)}
-            className="flex-grow"
+            className="flex-1"
           >
             {theme.name}
           </Button>


### PR DESCRIPTION
## Summary
- make theme preset buttons wrap on small screens

## Testing
- `pnpm lint` *(fails: ESLint configuration prompt)*
- `pnpm build` *(fails: Next.js build requires telemetry)*
- `pnpm test` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_684b329355d4832b9602b426a39e535d