### PR TITLE
Make image upload optional

### DIFF
--- a/src/app/api/generate/route.ts
+++ b/src/app/api/generate/route.ts
@@ -111,8 +111,7 @@ export async function POST(request: Request) {
       // Assuming promptText, userId are stored. Others like userPfpUrl might also be stored or passed differently.
       if (
         !generationRequest.promptText ||
-        typeof generationRequest.userId !== "string" ||
-        generationRequest.userPfpUrl === undefined
+        typeof generationRequest.userId !== "string"
       ) {
         console.error(
           "Critical data missing from generationRequest for job queuing",

--- a/src/app/generations/[id]/opengraph-image.tsx
+++ b/src/app/generations/[id]/opengraph-image.tsx
@@ -62,7 +62,7 @@ export default async function Image({ params }: { params: { id: string } }) {
       );
     }
 
-    if (!image.imageDataUrl || !image.userPfpUrl) {
+    if (!image.imageDataUrl) {
       return new ImageResponse(
         (
           <div
@@ -104,29 +104,33 @@ export default async function Image({ params }: { params: { id: string } }) {
             padding: "40px",
           }}
         >
-          {/* Source Image */}
-          <img
-            src={image.userPfpUrl}
-            alt="Source"
-            width={400}
-            height={400}
-            style={{
-              borderRadius: "50%",
-              objectFit: "cover",
-            }}
-          />
+          {image.userPfpUrl && (
+            <>
+              {/* Source Image */}
+              <img
+                src={image.userPfpUrl}
+                alt="Source"
+                width={400}
+                height={400}
+                style={{
+                  borderRadius: "50%",
+                  objectFit: "cover",
+                }}
+              />
 
-          {/* Arrow */}
-          <div
-            style={{
-              fontSize: 120,
-              color: "#666",
-              display: "flex",
-              alignItems: "center",
-            }}
-          >
-            →
-          </div>
+              {/* Arrow */}
+              <div
+                style={{
+                  fontSize: 120,
+                  color: "#666",
+                  display: "flex",
+                  alignItems: "center",
+                }}
+              >
+                →
+              </div>
+            </>
+          )}
 
           {/* Generated Image */}
           <img

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -652,11 +652,6 @@ export default function Home() {
     }
 
     const imageToUse = getImageToUse();
-    if (!imageToUse) {
-      setApiMessage("Please upload an image to stylize.");
-      setGenerationStep("error");
-      return;
-    }
 
     setApiMessage("Requesting generation quote...");
     setGenerationStep("quote_requested");
@@ -695,14 +690,18 @@ export default function Home() {
     isConfirming ||
     generationStep === "payment_processing" ||
     !getSelectedPrompt() ||
-    !hasValidAuth ||
-    !getImageToUse();
+    !hasValidAuth;
 
   const hasValidImage = getImageToUse();
   const showWarnings = {
-    noImage: !useUploadedImage && !unifiedUser?.profileImage && !uploadedImage,
     noUploadedImage: useUploadedImage && !uploadedImage,
   };
+
+  const generateButtonLabel = quoteMutation.isPending
+    ? "Processing..."
+    : hasValidImage
+    ? "Generate Character"
+    : "Generate without input image";
 
   if (isUserLoading || isAuthLoading) {
     return <div className="text-center py-10">Loading user data...</div>;
@@ -792,20 +791,17 @@ export default function Home() {
             onError={setApiMessage}
           />
 
-          {/* Theme Selection - only show if user has valid image */}
-          {hasValidImage && (
-            <ThemeSelector
-              selectedThemeId={selectedThemeId}
-              customPrompt={customPrompt}
-              onThemeSelect={setSelectedThemeId}
-              onCustomPromptChange={setCustomPrompt}
-              getSelectedPrompt={getSelectedPrompt}
-            />
-          )}
+          {/* Theme Selection */}
+          <ThemeSelector
+            selectedThemeId={selectedThemeId}
+            customPrompt={customPrompt}
+            onThemeSelect={setSelectedThemeId}
+            onCustomPromptChange={setCustomPrompt}
+            getSelectedPrompt={getSelectedPrompt}
+          />
 
           {/* Generate Button */}
-          {hasValidImage &&
-            generationStep !== "payment_processing" &&
+          {generationStep !== "payment_processing" &&
             generationStep !== "payment_submitted" &&
             generationStep !== "job_queued" && (
               <Button
@@ -813,9 +809,7 @@ export default function Home() {
                 className="w-full bg-purple-600 hover:bg-purple-700 text-white py-3 text-lg"
                 disabled={isActionDisabled}
               >
-                {quoteMutation.isPending
-                  ? "Processing..."
-                  : "Generate Character"}
+                {generateButtonLabel}
               </Button>
             )}
         </>

--- a/src/workers/stylize.ts
+++ b/src/workers/stylize.ts
@@ -22,17 +22,6 @@ export const stylizeImageWorker = new Worker<StylizeImageJobData>(
   async (job) => {
     const { userId, prompt, userPfpUrl, quoteId, n = 1 } = job.data;
 
-    if (!userPfpUrl) {
-      console.error(
-        `Job ID ${job.id} for userId ${userId}, quoteId ${quoteId}: Missing userPfpUrl. Cannot use image edit without an input image.`
-      );
-      await db
-        .updateTable("generatedImages")
-        .set({ status: "error", imageDataUrl: "Missing userPfpUrl for worker" })
-        .where("quoteId", "=", quoteId)
-        .execute();
-      throw new Error("userPfpUrl is required for image editing.");
-    }
     if (!quoteId) {
       console.error(
         `Job ID ${job.id} for userId ${userId}: Missing quoteId. Cannot update database record.`
@@ -41,69 +30,92 @@ export const stylizeImageWorker = new Worker<StylizeImageJobData>(
     }
 
     console.log(
-      `Processing image model image edit job for userId: ${userId}, quoteId: ${quoteId} with prompt: "${prompt}" and PFP URL: ${userPfpUrl.substring(
-        0,
-        50
-      )}...`
+      `Processing image generation job for userId: ${userId}, quoteId: ${quoteId} with prompt: "${prompt}"${
+        userPfpUrl ? ` and PFP URL: ${userPfpUrl.substring(0, 50)}` : ""
+      }...`
     );
 
     try {
-      let imageBuffer: Buffer;
-      let contentType: string;
+      let firstImageB64Json: string;
 
-      // Check if userPfpUrl is a data URL or regular URL
-      if (userPfpUrl.startsWith("data:")) {
-        // Handle data URL case
-        console.log(`Processing uploaded image data URL for job ${job.id}`);
+      if (userPfpUrl) {
+        let imageBuffer: Buffer;
+        let contentType: string;
 
-        const [mimeInfo, base64Data] = userPfpUrl.split(",");
-        if (!base64Data) {
-          throw new Error("Invalid data URL format: missing base64 data");
+        // Check if userPfpUrl is a data URL or regular URL
+        if (userPfpUrl.startsWith("data:")) {
+          // Handle data URL case
+          console.log(`Processing uploaded image data URL for job ${job.id}`);
+
+          const [mimeInfo, base64Data] = userPfpUrl.split(",");
+          if (!base64Data) {
+            throw new Error("Invalid data URL format: missing base64 data");
+          }
+
+          // Extract content type from data URL
+          const mimeMatch = mimeInfo.match(/data:([^;]+)/);
+          contentType = mimeMatch ? mimeMatch[1] : "image/png";
+
+          // Convert base64 to buffer
+          imageBuffer = Buffer.from(base64Data, "base64");
+        } else {
+          // Handle regular URL case
+          console.log(`Fetching image from URL for job ${job.id}: ${userPfpUrl}`);
+
+          const imageResponse = await fetch(userPfpUrl);
+          if (!imageResponse.ok) {
+            throw new Error(
+              `Failed to fetch image from ${userPfpUrl}: ${imageResponse.statusText}`
+            );
+          }
+          imageBuffer = Buffer.from(await imageResponse.arrayBuffer());
+          contentType = imageResponse.headers.get("content-type") || "image/png";
         }
 
-        // Extract content type from data URL
-        const mimeMatch = mimeInfo.match(/data:([^;]+)/);
-        contentType = mimeMatch ? mimeMatch[1] : "image/png";
+        const imageFile = await toFile(imageBuffer, "profile.png", {
+          type: contentType,
+        });
 
-        // Convert base64 to buffer
-        imageBuffer = Buffer.from(base64Data, "base64");
-      } else {
-        // Handle regular URL case
-        console.log(`Fetching image from URL for job ${job.id}: ${userPfpUrl}`);
+        const response = await openaiClient.images.edit({
+          model: "gpt-image-1",
+          image: imageFile,
+          prompt: prompt,
+          n: n,
+          size: "1024x1024",
+        });
 
-        const imageResponse = await fetch(userPfpUrl);
-        if (!imageResponse.ok) {
+        if (
+          !response.data ||
+          response.data.length === 0 ||
+          !response.data[0].b64_json
+        ) {
           throw new Error(
-            `Failed to fetch image from ${userPfpUrl}: ${imageResponse.statusText}`
+            "No b64_json data received from OpenAI API after edit."
           );
         }
-        imageBuffer = Buffer.from(await imageResponse.arrayBuffer());
-        contentType = imageResponse.headers.get("content-type") || "image/png";
+
+        firstImageB64Json = response.data[0].b64_json;
+      } else {
+        const response = await openaiClient.images.generate({
+          model: "dall-e-3",
+          prompt: prompt,
+          n: n,
+          size: "1024x1024",
+          response_format: "b64_json",
+        });
+
+        if (
+          !response.data ||
+          response.data.length === 0 ||
+          !response.data[0].b64_json
+        ) {
+          throw new Error(
+            "No b64_json data received from OpenAI API after generation."
+          );
+        }
+
+        firstImageB64Json = response.data[0].b64_json;
       }
-
-      const imageFile = await toFile(imageBuffer, "profile.png", {
-        type: contentType,
-      });
-
-      const response = await openaiClient.images.edit({
-        model: "gpt-image-1",
-        image: imageFile,
-        prompt: prompt,
-        n: n, // Number of images to generate
-        size: "1024x1024",
-      });
-
-      if (
-        !response.data ||
-        response.data.length === 0 ||
-        !response.data[0].b64_json
-      ) {
-        throw new Error(
-          "No b64_json data received from OpenAI API after edit."
-        );
-      }
-
-      const firstImageB64Json = response.data[0].b64_json;
 
       // Convert base64 to buffer
       const generatedImageBuffer = Buffer.from(firstImageB64Json, "base64");
@@ -152,10 +164,10 @@ export const stylizeImageWorker = new Worker<StylizeImageJobData>(
       return { b64JsonImage: resizedImageB64Json }; // Return resized image
     } catch (error) {
       console.error(
-        `Job ID ${job.id} for userId ${userId}, quoteId ${quoteId}: Error during image model image edit -`,
+        `Job ID ${job.id} for userId ${userId}, quoteId ${quoteId}: Error during image generation -`,
         error
       );
-      let errorMessage = "Image editing failed.";
+      let errorMessage = "Image generation failed.";
       if (error instanceof Error) errorMessage = error.message;
 
       try {


### PR DESCRIPTION
## Summary
- allow job creation without userPfpUrl
- generate image from prompt when no input image is supplied
- show theme selector and generate button even without an image
- adjust OpenGraph page to handle missing userPfpUrl
- change CTA label when no image selected

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm test` *(fails: No tests found)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68567de7753c832b86f01e5b8eff9041