### PR TITLE
Implement share URL redirect with prompt

### DIFF
--- a/src/app/generations/[id]/page.tsx
+++ b/src/app/generations/[id]/page.tsx
@@ -1,6 +1,7 @@
 import { FRAME_METADATA } from "@/lib/constants";
 import { Metadata } from "next";
 import { redirect } from "next/navigation";
+import { db } from "@/lib/db";
 
 export async function generateMetadata({
   params,
@@ -21,6 +22,25 @@ export async function generateMetadata({
   };
 }
 
-export default function Page() {
+export default async function Page({
+  params,
+}: {
+  params: { id: string };
+}) {
+  try {
+    const image = await db
+      .selectFrom("generatedImages")
+      .select(["promptText"])
+      .where("id", "=", params.id)
+      .executeTakeFirst();
+
+    if (image?.promptText) {
+      const encoded = encodeURIComponent(image.promptText);
+      redirect(`/?prompt=${encoded}`);
+      return;
+    }
+  } catch (e) {
+    console.error("Error fetching prompt", e);
+  }
   redirect("/");
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,7 @@ import { useUser } from "../providers/UserContextProvider";
 import { Button } from "@/components/ui/button";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useState, useEffect } from "react";
+import { useSearchParams } from "next/navigation";
 import {
   useSendTransaction,
   useAccount,
@@ -110,6 +111,7 @@ export default function Home() {
   const { user: farcasterUser, isLoading: isUserLoading } = useUser();
   const { address: connectedAddress } = useAccount();
   const account = useAccount();
+  const searchParams = useSearchParams();
 
   // Unified Authentication (supports both SIWE and Farcaster)
   const {
@@ -171,6 +173,19 @@ export default function Home() {
   const [isPaymentSubmitted, setIsPaymentSubmitted] = useState<boolean>(false);
   const [isPolling, setIsPolling] = useState<boolean>(false);
   const [pollingQuoteId, setPollingQuoteId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const promptParam = searchParams.get("prompt");
+    if (promptParam) {
+      const matching = themes.find((t) => t.prompt === promptParam);
+      if (matching) {
+        setSelectedThemeId(matching.id);
+        setCustomPrompt("");
+      } else {
+        setCustomPrompt(promptParam);
+      }
+    }
+  }, []);
 
   // Wagmi hooks
   const {


### PR DESCRIPTION
## Summary
- add DB lookup when visiting `/generations/[id]` to redirect with the saved prompt
- read `prompt` query param on the homepage and select the matching theme or custom prompt

## Testing
- `pnpm lint` *(fails: ESLint configuration missing)*
- `pnpm build`
- `pnpm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_685c12756d20832b90456cabc1214997