### PR TITLE
Standardize image url retrieval and add input image endpoint

### DIFF
--- a/src/app/api/images/[id]/input/route.ts
+++ b/src/app/api/images/[id]/input/route.ts
@@ -14,12 +14,8 @@ export async function GET(
       .selectFrom("generatedImages")
       .select([
         "id",
-        "imageDataUrl",
-        "status",
-        "promptText",
         "userPfpUrl",
-        "createdAt",
-        "quoteId",
+        "status",
       ])
       .where("id", "=", imageId)
       .executeTakeFirst();
@@ -32,14 +28,14 @@ export async function GET(
       return new NextResponse("Image not ready", { status: 400 });
     }
 
-    if (!image.imageDataUrl) {
-      return new NextResponse("Image data not available", { status: 404 });
+    if (!image.userPfpUrl) {
+      return new NextResponse("Input image not available", { status: 404 });
     }
 
-    // Check if imageDataUrl is a data URL (base64 encoded)
-    if (image.imageDataUrl.startsWith("data:")) {
+    // Check if userPfpUrl is a data URL (base64 encoded)
+    if (image.userPfpUrl.startsWith("data:")) {
       // Extract the base64 data and content type
-      const [mimeInfo, base64Data] = image.imageDataUrl.split(",");
+      const [mimeInfo, base64Data] = image.userPfpUrl.split(",");
       if (!base64Data) {
         return new NextResponse("Invalid image data", { status: 400 });
       }
@@ -60,10 +56,10 @@ export async function GET(
       });
     } else {
       // For regular URLs, redirect to the original URL
-      return NextResponse.redirect(image.imageDataUrl);
+      return NextResponse.redirect(image.userPfpUrl);
     }
   } catch (error) {
-    console.error("Error serving image:", error);
+    console.error("Error serving input image:", error);
     return new NextResponse("Internal Server Error", { status: 500 });
   }
 }

--- a/src/app/api/images/route.ts
+++ b/src/app/api/images/route.ts
@@ -2,6 +2,7 @@ import { SIWE_JWT_COOKIE_NAME } from "@/lib/constants";
 import { db } from "@/lib/db";
 import { withAuth } from "@/lib/siwe-auth";
 import { NextResponse } from "next/server";
+import { getImageUrl, getInputImageUrl } from "@/lib/image-utils";
 
 export const GET = withAuth(async ({ user }) => {
   try {
@@ -21,12 +22,10 @@ export const GET = withAuth(async ({ user }) => {
       .selectFrom("generatedImages")
       .select([
         "id", // or quoteId if that's the unique identifier for an image item
-        "imageDataUrl",
         "promptText",
         "createdAt",
         "status", // good for debugging, or if UI wants to re-verify
         "quoteId",
-        "userPfpUrl",
       ])
       .where("userId", "ilike", user.id.toString().toLowerCase())
       .where("status", "=", "completed")
@@ -44,8 +43,15 @@ export const GET = withAuth(async ({ user }) => {
       );
     }
 
+    // Transform the images to include URLs instead of raw data
+    const imagesWithUrls = completedImages.map(image => ({
+      ...image,
+      imageDataUrl: getImageUrl(image.id),
+      userPfpUrl: getInputImageUrl(image.id),
+    }));
+
     return NextResponse.json({
-      images: completedImages,
+      images: imagesWithUrls,
       authenticatedUser: user.address, // Include for debugging
     });
   } catch (error) {

--- a/src/app/api/jobs/route.ts
+++ b/src/app/api/jobs/route.ts
@@ -1,6 +1,7 @@
 import { db } from "@/lib/db";
 import { withAuth } from "@/lib/siwe-auth";
 import { NextResponse } from "next/server";
+import { getInputImageUrl } from "@/lib/image-utils";
 
 export const GET = withAuth(async ({ user }) => {
   try {
@@ -8,7 +9,6 @@ export const GET = withAuth(async ({ user }) => {
       .selectFrom("generatedImages")
       .select([
         "id",
-        "userPfpUrl",
         "promptText",
         "createdAt",
         "status",
@@ -26,7 +26,13 @@ export const GET = withAuth(async ({ user }) => {
       .orderBy("createdAt", "desc")
       .execute();
 
-    return NextResponse.json({ jobs: inProgressJobs });
+    // Transform the jobs to include URLs instead of raw data
+    const jobsWithUrls = inProgressJobs.map(job => ({
+      ...job,
+      userPfpUrl: getInputImageUrl(job.id),
+    }));
+
+    return NextResponse.json({ jobs: jobsWithUrls });
   } catch (error) {
     console.error(`Error fetching in-progress jobs for userId ${user}:`, error);
     let errorMessage = "Internal Server Error";

--- a/src/app/generations/[id]/page.tsx
+++ b/src/app/generations/[id]/page.tsx
@@ -6,6 +6,7 @@ import { Sparkles } from "lucide-react";
 import { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
+import { getImageUrl, getInputImageUrl } from "@/lib/image-utils";
 
 export async function generateMetadata({
   params,
@@ -47,11 +48,9 @@ export default async function Page({
   const image = await db
     .selectFrom("generatedImages")
     .select([
-      "imageDataUrl",
       "status",
       "createdAt",
       "quoteId",
-      "userPfpUrl",
       "promptText",
     ])
     .where("id", "=", id)
@@ -69,10 +68,10 @@ export default async function Page({
           image={{
             createdAt: image.createdAt.toISOString(),
             id,
-            imageDataUrl: image.imageDataUrl,
+            imageDataUrl: getImageUrl(id),
             promptText: image.promptText,
             quoteId: image.quoteId,
-            userPfpUrl: image.userPfpUrl,
+            userPfpUrl: getInputImageUrl(id),
           }}
         />
         <div className="flex justify-center">

--- a/src/lib/image-utils.ts
+++ b/src/lib/image-utils.ts
@@ -178,13 +178,24 @@ export function checkIfResizeNeeded(
 }
 
 /**
+ * Gets the base URL for the application
+ * @returns The base URL
+ */
+export function getBaseUrl(): string {
+  const appUrl =
+    process.env.VERCEL_ENV === "preview" && process.env.VERCEL_BRANCH_URL
+      ? `https://${process.env.VERCEL_BRANCH_URL}`
+      : process.env.APP_URL!;
+  return appUrl;
+}
+
+/**
  * Gets the URL for an image by ID
  * @param imageId - The ID of the image
  * @returns The URL for the image
  */
 export function getImageUrl(imageId: string): string {
-  const baseUrl = process.env.APP_URL || process.env.NEXT_PUBLIC_APP_URL || '';
-  return `${baseUrl}/api/images/${imageId}`;
+  return `${getBaseUrl()}/api/images/${imageId}`;
 }
 
 /**
@@ -193,6 +204,5 @@ export function getImageUrl(imageId: string): string {
  * @returns The URL for the input image
  */
 export function getInputImageUrl(imageId: string): string {
-  const baseUrl = process.env.APP_URL || process.env.NEXT_PUBLIC_APP_URL || '';
-  return `${baseUrl}/api/images/${imageId}/input`;
+  return `${getBaseUrl()}/api/images/${imageId}/input`;
 }

--- a/src/lib/image-utils.ts
+++ b/src/lib/image-utils.ts
@@ -184,7 +184,7 @@ export function checkIfResizeNeeded(
  */
 export function getImageUrl(imageId: string): string {
   const baseUrl = process.env.APP_URL || process.env.NEXT_PUBLIC_APP_URL || '';
-  return `${baseUrl}/images/${imageId}`;
+  return `${baseUrl}/api/images/${imageId}`;
 }
 
 /**
@@ -194,5 +194,5 @@ export function getImageUrl(imageId: string): string {
  */
 export function getInputImageUrl(imageId: string): string {
   const baseUrl = process.env.APP_URL || process.env.NEXT_PUBLIC_APP_URL || '';
-  return `${baseUrl}/images/${imageId}/input`;
+  return `${baseUrl}/api/images/${imageId}/input`;
 }

--- a/src/lib/image-utils.ts
+++ b/src/lib/image-utils.ts
@@ -176,3 +176,23 @@ export function checkIfResizeNeeded(
     img.src = URL.createObjectURL(file);
   });
 }
+
+/**
+ * Gets the URL for an image by ID
+ * @param imageId - The ID of the image
+ * @returns The URL for the image
+ */
+export function getImageUrl(imageId: string): string {
+  const baseUrl = process.env.APP_URL || process.env.NEXT_PUBLIC_APP_URL || '';
+  return `${baseUrl}/images/${imageId}`;
+}
+
+/**
+ * Gets the URL for an input image by ID
+ * @param imageId - The ID of the image
+ * @returns The URL for the input image
+ */
+export function getInputImageUrl(imageId: string): string {
+  const baseUrl = process.env.APP_URL || process.env.NEXT_PUBLIC_APP_URL || '';
+  return `${baseUrl}/images/${imageId}/input`;
+}


### PR DESCRIPTION
Introduce image URL helper functions and a new `/images/[id]/input` endpoint to serve image data via URLs instead of embedding base64 data in API responses.

The previous method of embedding base64 encoded image data directly into API responses for `imageDataUrl` and `userPfpUrl` resulted in large payloads, impacting performance and preventing efficient caching. This PR provides dedicated image endpoints and helper functions to return URLs, improving performance, consistency, caching, and reducing security risks by avoiding direct data exposure in general API responses.