### PR TITLE
Conditionally pad drawer footer for mini app

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useIsMobile } from "@/hooks/use-mobile";
+import { useMiniAppContext } from "@/providers/MiniAppContextProvider";
 import { Plus, Image } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
@@ -16,8 +17,14 @@ export function Navigation() {
   }
 
   if (isMobile) {
+    const { context } = useMiniAppContext();
+    const isMiniApp = !!context;
+    
     return (
-      <div className="fixed bottom-0 left-0 right-0 bg-white dark:bg-gray-900 border-t border-gray-200 dark:border-gray-700 pb-4">
+      <div className={clsx(
+        "fixed bottom-0 left-0 right-0 bg-white dark:bg-gray-900 border-t border-gray-200 dark:border-gray-700",
+        isMiniApp && "pb-4"
+      )}>
         <div className="flex justify-around items-center py-4">
           <Link href="/">
             <Plus

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -23,7 +23,7 @@ export function Navigation() {
     return (
       <div className={clsx(
         "fixed bottom-0 left-0 right-0 bg-white dark:bg-gray-900 border-t border-gray-200 dark:border-gray-700",
-        isMiniApp && "pb-4"
+        isMiniApp && `pb-[${context?.client?.safeAreaInsets?.bottom ?? 4}px]`
       )}>
         <div className="flex justify-around items-center py-4">
           <Link href="/">

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import { Drawer as DrawerPrimitive } from "vaul";
 
 import { cn } from "@/lib/utils";
+import { useMiniAppContext } from "@/providers/MiniAppContextProvider";
 
 const Drawer = ({
   shouldScaleBackground = true,
@@ -69,12 +70,21 @@ DrawerHeader.displayName = "DrawerHeader";
 const DrawerFooter = ({
   className,
   ...props
-}: React.HTMLAttributes<HTMLDivElement>) => (
-  <div
-    className={cn("mt-auto flex flex-col gap-2 p-4 mb-4", className)}
-    {...props}
-  />
-);
+}: React.HTMLAttributes<HTMLDivElement>) => {
+  const { context } = useMiniAppContext();
+  const isMiniApp = !!context;
+  
+  return (
+    <div
+      className={cn(
+        "mt-auto flex flex-col gap-2 p-4",
+        isMiniApp && "mb-4",
+        className
+      )}
+      {...props}
+    />
+  );
+};
 DrawerFooter.displayName = "DrawerFooter";
 
 const DrawerTitle = React.forwardRef<

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -78,7 +78,7 @@ const DrawerFooter = ({
     <div
       className={cn(
         "mt-auto flex flex-col gap-2 p-4",
-        isMiniApp && "mb-4",
+        isMiniApp && `mb-[${context?.client?.safeAreaInsets?.bottom ?? 4}px]`,
         className
       )}
       {...props}


### PR DESCRIPTION
Conditionally add bottom padding to the drawer footer and mobile navigation only when in a mini app context.