### PR TITLE
Fix auto-opened drawer close failure

### DIFF
--- a/src/app/(auth)/gallery/page.tsx
+++ b/src/app/(auth)/gallery/page.tsx
@@ -5,7 +5,7 @@ import { JobsSection } from "@/components/JobsSection";
 import { CreationsGallery } from "@/components/CreationsGallery";
 import { UserThemes } from "@/components/UserThemes";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { useSearchParams } from "next/navigation";
+import { useSearchParams, useRouter } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
 import { useState } from "react";
 import { ImageDetailModal } from "@/components/ImageDetailModal";
@@ -13,6 +13,7 @@ import type { CompletedImage } from "@/components/CreationItem";
 
 export default function GalleryPage() {
   const searchParams = useSearchParams();
+  const router = useRouter();
   const imageId = searchParams.get("imageId");
   const [selectedImage, setSelectedImage] = useState<CompletedImage | null>(null);
 
@@ -41,6 +42,12 @@ export default function GalleryPage() {
   const handleModalClose = (open: boolean) => {
     if (!open) {
       setSelectedImage(null);
+      // Clean up the URL parameter when modal is closed
+      if (imageId) {
+        const newSearchParams = new URLSearchParams(searchParams);
+        newSearchParams.delete("imageId");
+        router.replace(`/gallery?${newSearchParams.toString()}`);
+      }
     }
   };
 

--- a/src/components/ImageDetailModal.tsx
+++ b/src/components/ImageDetailModal.tsx
@@ -3,6 +3,7 @@ import {
   Credenza,
   CredenzaContent,
   CredenzaTitle,
+  CredenzaClose,
 } from "@/components/ui/credenza";
 import {
   Popover,
@@ -23,6 +24,7 @@ import {
   RefreshCw,
   Share2,
   Twitter,
+  X,
 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
@@ -125,7 +127,11 @@ export function ImageDetailModal({
 
   return (
     <Credenza open={open} onOpenChange={onOpenChange}>
-      <CredenzaContent className="max-w-md">
+      <CredenzaContent className="max-w-md relative">
+        <CredenzaClose className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+          <X className="h-4 w-4" />
+          <span className="sr-only">Close</span>
+        </CredenzaClose>
         <CredenzaTitle className="sr-only">Image</CredenzaTitle>
         <div className="space-y-4 p-4">
           {/* Loading state with skeletons */}


### PR DESCRIPTION
Clean up `imageId` URL parameter on ImageDetail modal close and add a close button to prevent automatic reopening.

The drawer was opening automatically based on the `imageId` URL parameter. When the user closed the drawer, the `imageId` parameter remained in the URL, causing the component to re-render and reopen the drawer immediately. This PR ensures the URL parameter is removed upon closing, preventing this loop. Additionally, a close button is added for better user experience.