### PR TITLE
Skip same user referring image id in generate

### DIFF
--- a/src/app/api/generate/route.ts
+++ b/src/app/api/generate/route.ts
@@ -204,9 +204,25 @@ export async function POST(request: Request) {
 
       const newQuoteId = randomUUID();
 
+      // Check if referring image exists and belongs to the same user
+      let finalReferringImageId = referringImageId;
+      if (referringImageId) {
+        const referringImage = await db
+          .selectFrom("generatedImages")
+          .select("userId")
+          .where("id", "=", referringImageId)
+          .where("status", "=", "completed")
+          .executeTakeFirst();
+
+        // If referring image belongs to the same user, don't set referringImageId
+        if (referringImage && referringImage.userId === userId) {
+          finalReferringImageId = null;
+        }
+      }
+
       const royalties = await calculateRoyalties({
         prompt,
-        referringImageId,
+        referringImageId: finalReferringImageId,
       });
 
       const insertedRecord = await db
@@ -217,7 +233,7 @@ export async function POST(request: Request) {
           quoteId: newQuoteId,
           status: "pending_payment",
           userPfpUrl: userPfpUrl,
-          referringImageId,
+          referringImageId: finalReferringImageId,
         })
         .returning("id")
         .executeTakeFirstOrThrow();


### PR DESCRIPTION
Prevent storing `referringImageId` and calculating royalties when a user references their own image in `/api/generate`.

---

[Open in Web](https://www.cursor.com/agents?id=bc-b5ffeecf-77bb-4e26-8104-7916ccfb7a2e) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-b5ffeecf-77bb-4e26-8104-7916ccfb7a2e)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)